### PR TITLE
Exclude string double quotes removed

### DIFF
--- a/src/helper/google.js
+++ b/src/helper/google.js
@@ -19,7 +19,7 @@ const makeExcludeString = (exclude) => {
     if (exclude.indexOf(",")) {
       let excluded = exclude.split(",");
       for (let iterator of excluded) {
-        excludedString += ` -"${iterator.trim()}"`;
+        excludedString += ` -${iterator.trim()}`;
       }
     }
     return excludedString;


### PR DESCRIPTION
If it is single including double quotes will not work, we should explicitly mention that you should enter phares in double quotes